### PR TITLE
ci: add Claude Code workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,54 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+env:
+  # Centralized prompt - edit in dotfiles repo, all repos pick up changes
+  PROMPT_URL: https://raw.githubusercontent.com/evansenter/dotfiles/main/home/.claude/contrib/prompts/claude-review.md
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # Needed to post comments
+      issues: write         # Read linked issues, optionally comment if PR incomplete
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Fetch review prompt
+        id: prompt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if curl -sfL "$PROMPT_URL" > /tmp/review-prompt.md && [ -s /tmp/review-prompt.md ]; then
+            echo "Fetched review prompt ($(wc -l < /tmp/review-prompt.md) lines)"
+            echo "use_file=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Failed to fetch centralized prompt from $PROMPT_URL - using fallback"
+            echo "use_file=false" >> "$GITHUB_OUTPUT"
+            # Post warning comment on PR
+            gh pr comment ${{ github.event.pull_request.number }} --body "⚠️ **Claude Review Warning**: Could not fetch centralized review prompt from \`$PROMPT_URL\`. Using fallback inline prompt. This may result in less thorough reviews."
+          fi
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+
+            ${{ steps.prompt.outputs.use_file == 'true' && 'First, read the review instructions from /tmp/review-prompt.md using your Read tool. Then follow those instructions to review this PR.' || 'Review this PR for code quality, bugs, security issues, and adherence to project conventions (check CLAUDE.md). Check for previous "Feedback Addressed" comments to avoid re-raising resolved issues. Be strict: REQUEST_CHANGES for any issues found, only APPROVE if genuinely ready to merge. Submit your review using gh api repos/$REPO/pulls/$PR_NUMBER/reviews with inline comments on specific files/lines and event set to APPROVE or REQUEST_CHANGES. Start the review body with: > **Prompt:** Fallback (centralized prompt fetch failed)' }}
+
+            Use the REPO and PR_NUMBER variables provided above.
+          # Tools required by the centralized prompt (see contrib/prompts/claude-review.md)
+          claude_args: '--model opus --allowed-tools "Read,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## Summary
- Adds `claude.yml` — responds to `@claude` mentions in issues and PRs
- Adds `claude-code-review.yml` — auto-reviews PRs on open/synchronize using centralized review prompt from dotfiles

Both use the `CLAUDE_CODE_OAUTH_TOKEN` secret (already configured via `/install-github-app`).

## Test plan
- [ ] Create a test PR and verify claude-code-review triggers
- [ ] Comment `@claude` on an issue and verify response

🤖 Generated with [Claude Code](https://claude.com/claude-code)